### PR TITLE
Set up for Minecraft 1.21.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20
-yarn_mappings=1.20+build.1
+minecraft_version=1.21.1
+yarn_mappings=1.21.1+build.3
 loader_version=0.15.11
 
 # Mod Properties
@@ -14,5 +14,5 @@ maven_group=com.kevinsundqvistnorlen
 archives_base_name=rubi
 
 # Dependencies
-fabric_version=0.83.0+1.20
+fabric_version=0.102.1+1.21.1
 minecraft_range=1.20.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ archives_base_name=rubi
 
 # Dependencies
 fabric_version=0.102.1+1.21.1
-minecraft_range=1.20.0
+minecraft_range=1.21.1


### PR DESCRIPTION
I updated the properties in `gradle.properties` to work for Minecraft 1.21.1 as per [Develop | Fabric](https://fabricmc.net/develop/).