### PR TITLE
Added check for correct codePoint

### DIFF
--- a/src/main/java/com/kevinsundqvistnorlen/rubi/IRubyStyle.java
+++ b/src/main/java/com/kevinsundqvistnorlen/rubi/IRubyStyle.java
@@ -9,6 +9,11 @@ public interface IRubyStyle {
         return Optional.ofNullable(((IRubyStyle) style).rubi$getRuby());
     }
 
+    static Optional<RubyText> getRuby(Style style, int codePoint) {
+        if (codePoint != '￼') return Optional.empty();
+        return getRuby(style);
+    }
+
     Style rubi$withRuby(RubyText rubyText);
 
     RubyText rubi$getRuby();

--- a/src/main/java/com/kevinsundqvistnorlen/rubi/TextDrawer.java
+++ b/src/main/java/com/kevinsundqvistnorlen/rubi/TextDrawer.java
@@ -14,7 +14,7 @@ public interface TextDrawer {
         var xx = new MutableFloat(x);
         text.accept((index, style, codePoint) -> {
             xx.add(IRubyStyle
-                .getRuby(style)
+                .getRuby(style, codePoint)
                 .map(rubyText -> rubyText.draw(xx.getValue(), y, matrix, textHandler, fontHeight, textDrawer))
                 .orElseGet(() -> {
                     var styledChar = OrderedText.styled(codePoint, style);

--- a/src/main/java/com/kevinsundqvistnorlen/rubi/mixin/client/MixinTextHandler.java
+++ b/src/main/java/com/kevinsundqvistnorlen/rubi/mixin/client/MixinTextHandler.java
@@ -22,7 +22,7 @@ public abstract class MixinTextHandler {
         @Local(argsOnly = true) LocalRef<TextHandler.WidthRetriever> localWidthRetriever
     ) {
         localWidthRetriever.set((codePoint, style) -> IRubyStyle
-            .getRuby(style)
+            .getRuby(style, codePoint)
             .map(rubyText -> rubyText.getWidth((TextHandler) (Object) this))
             .orElseGet(() -> widthRetriever.getWidth(codePoint, style)));
     }
@@ -52,7 +52,7 @@ public abstract class MixinTextHandler {
             text.accept((index, style, codePoint) -> {
                 width.add(
                     IRubyStyle
-                        .getRuby(style)
+                        .getRuby(style, codePoint)
                         .map(ruby -> ruby.getWidth((TextHandler) (Object) this))
                         .orElseGet(() -> this.getWidth(OrderedText.styled(codePoint, style)))
                 );


### PR DESCRIPTION
In wrapped strings non-rubi characters will sometimes get the style of the proceeding rubi-character